### PR TITLE
Merger til main

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*  @navikt/pim
+*  #prim


### PR DESCRIPTION
NO-JIRA: Fjernet team PIM som CODEOWNERS for å redusere antall varsler på mail angående nye PR. La inn #prim for å fortelle folk hvor de kan få tak i oss